### PR TITLE
TOXVAL-365

### DIFF
--- a/R/import_source_epa_ow_npdwr.R
+++ b/R/import_source_epa_ow_npdwr.R
@@ -9,19 +9,19 @@
 #' @description FUNCTION_DESCRIPTION
 #' @return OUTPUT_DESCRIPTION
 #' @details DETAILS
-#' @examples 
+#' @examples
 #' \dontrun{
 #' if(interactive()){
 #'  #EXAMPLE1
 #'  }
 #' }
-#' @seealso 
+#' @seealso
 #'  \code{\link[readxl]{read_excel}}
 #'  \code{\link[dplyr]{rename}}, \code{\link[dplyr]{mutate}}, \code{\link[dplyr]{across}}
 #'  \code{\link[tidyr]{pivot_longer}}, \code{\link[tidyr]{separate}}
 #'  \code{\link[stringr]{str_trim}}
 #' @rdname import_source_epa_ow_npdwr
-#' @export 
+#' @export
 #' @importFrom readxl read_xlsx
 #' @importFrom dplyr rename mutate across
 #' @importFrom tidyr pivot_longer separate
@@ -31,6 +31,8 @@ import_source_epa_ow_npdwr <- function(db,chem.check.halt=FALSE, do.reset=FALSE,
   printCurrentFunction(db)
   source = "EPA OW NPDWR"
   source_table = "source_epa_ow_npdwr"
+  # Date provided by the source or the date the data was extracted
+  src_version_date = as.Date("2023-02-28")
   dir = paste0(toxval.config()$datapath,"epa_ow_npdwr/epa_ow_npdwr_files/")
   file = paste0(dir,"epa_ow_npdwr_raw.xlsx")
   res0 = readxl::read_xlsx(file)
@@ -44,7 +46,7 @@ import_source_epa_ow_npdwr <- function(db,chem.check.halt=FALSE, do.reset=FALSE,
   # described in the SOP - they will get added in source_prep_and_load
   #
   # Load and clean source
-  res0 <- res0 %>%
+  res <- res0 %>%
     dplyr::rename(name = Contaminant) %>%
     # Pivot MCLG and MCL columns to toxval_type and _numeric
     tidyr::pivot_longer(c("MCLG (mg/L)", "MCL or TT (mg/L)"),
@@ -63,44 +65,43 @@ import_source_epa_ow_npdwr <- function(db,chem.check.halt=FALSE, do.reset=FALSE,
                   toxval_numeric = gsub(" MFL$", " million fibers per liter", toxval_numeric)) %>%
     dplyr::mutate(dplyr::across(c("toxval_type", "toxval_numeric", "toxval_units"),
                          ~stringr::str_squish(.))) %>%
-    dplyr::rename(critical_effect="Potential Health Effects from Long-Term Exposure Above the MCL (unless specified as short-term)")
-    
-  # Drop rows with subsource type as Microorganisms or Radionuclides
-  # Drop rows with toxval_numeric TT/-/NA
-    res <- subset(res0, subsource_type!="Microorganisms" & subsource_type!="Radionuclides") 
-    res <- subset(res0, toxval_numeric!="TT; Action Level=1.3" & toxval_numeric!="TT; Action Level=0.015"
-                  & toxval_numeric!= "TT" & toxval_numeric!="-" & toxval_numeric!="NA" & toxval_numeric!="N/A") 
+    dplyr::rename(critical_effect="Potential Health Effects from Long-Term Exposure Above the MCL (unless specified as short-term)") %>%
+    # Drop rows with subsource type as Microorganisms or Radionuclides
+    dplyr::filter(!subsource_type %in% c("Microorganisms", "Radionuclides"),
+                  # Drop rows with toxval_numeric TT/-/NA
+                  !grepl("TT;|^TT", toxval_numeric),
+                  !toxval_numeric %in% c("N/A", "NA", "-"),
+                  !is.na(toxval_numeric))
+
   # Fixing toxval_numeric values that have the units with them (split into numeric and units)
-   res <- within(res, toxval_units[toxval_numeric=='7 million fibers per liter'] <- 'MFL')
-   res <- within(res, toxval_numeric[toxval_numeric=='7 million fibers per liter'] <- '7')
-   res <- within(res, toxval_units[toxval_numeric=='7 million fibers per liter (MFL)'] <- 'MFL')
-   res <- within(res, toxval_numeric[toxval_numeric=='7 million fibers per liter (MFL)'] <- '7')
-   res <- within(res, toxval_units[toxval_numeric=='15 picocuries per Liter (pCi/L)'] <- 'pCi/L')
-   res <- within(res, toxval_numeric[toxval_numeric=='15 picocuries per Liter (pCi/L)'] <- '15')
-   res <- within(res, toxval_units[toxval_numeric=='5 pCi/L'] <- 'pCi/L')
-   res <- within(res, toxval_numeric[toxval_numeric=='5 pCi/L'] <- '5')
-   res <- within(res, toxval_units[toxval_numeric=='30 ug/L'] <- 'ug/L')
-   res <- within(res, toxval_numeric[toxval_numeric=='30 ug/L'] <- '30')
-   res <- within(res, toxval_units[toxval_numeric=='4 millirems per year'] <- 'millirems per year')
-   res <- within(res, toxval_numeric[toxval_numeric=='4 millirems per year'] <- '4')
-   # Fixing toxval_numeric values that have toxval_types in them (split into numeric and toxval_type)
-   res <- within(res, toxval_type[toxval_numeric=='MRDLG=4'] <- 'MRDLG')
-   res <- within(res, toxval_numeric[toxval_numeric=='MRDLG=4'] <- '4')
-   res <- within(res, toxval_type[toxval_numeric=='MRDL=4.0'] <- 'MRDL')
-   res <- within(res, toxval_numeric[toxval_numeric=='MRDL=4.0'] <- '4')
-   res <- within(res, toxval_type[toxval_numeric=='MRDL=0.8'] <- 'MRDL')
-   res <- within(res, toxval_numeric[toxval_numeric=='MRDL=0.8'] <- '0.8')
-   res <- within(res, toxval_type[toxval_numeric=='MRDLG=0.8'] <- 'MRDLG')
-   res <- within(res, toxval_numeric[toxval_numeric=='MRDLG=0.8'] <- '0.8')
-   
+  res$toxval_units[res$toxval_numeric == '7 million fibers per liter'] <- 'MFL'
+  res$toxval_numeric[res$toxval_numeric == '7 million fibers per liter'] <- '7'
+  res$toxval_units[res$toxval_numeric == '7 million fibers per liter (MFL)'] <- 'MFL'
+  res$toxval_numeric[res$toxval_numeric == '7 million fibers per liter (MFL)'] <- '7'
+  # Fixing toxval_numeric values that have toxval_types in them (split into numeric and toxval_type)
+  res$toxval_type[res$toxval_numeric=='MRDL=4.0'] <- 'MRDL'
+  res$toxval_numeric[res$toxval_numeric=='MRDL=4.0'] <- '4'
+  res$toxval_type[res$toxval_numeric=='MRDLG=4'] <- 'MRDLG'
+  res$toxval_numeric[res$toxval_numeric=='MRDLG=4'] <- '4'
+  res$toxval_type[res$toxval_numeric=='MRDLG=0.8'] <- 'MRDLG'
+  res$toxval_numeric[res$toxval_numeric=='MRDLG=0.8'] <- '0.8'
+  res$toxval_type[res$toxval_numeric=='MRDL=0.8'] <- 'MRDL'
+  res$toxval_numeric[res$toxval_numeric=='MRDL=0.8'] <- '0.8'
+
+  # Convert to numeric
+  res$toxval_numeric <- as.numeric(res$toxval_numeric)
 
   # Standardize the names
-  names(res0) <- names(res0) %>%
+  names(res) <- names(res) %>%
     stringr::str_squish() %>%
     # Replace whitespace and periods with underscore
     gsub("[[:space:]]|[.]", "_", .) %>%
     tolower()
 
+  # Add version date. Can be converted to a mutate statement as needed
+  res$source_version_date <- src_version_date
+  # Placeholder cas field since none provided
+  res$casrn <- NA
   #####################################################################
   cat("Prep and load the data\n")
   #####################################################################

--- a/R/toxval.config.R
+++ b/R/toxval.config.R
@@ -41,7 +41,7 @@ toxval.config <- function() {
   dsstox.db <- "ro_prod_dsstox"
   source.db <- "res_toxval_source_v5"
 
-  datapath = "/ccte/ACToR1/ToxValDB9/Repo/"
+  datapath = "Repo/"#"/ccte/ACToR1/ToxValDB9/Repo/"
   actorws.prod <- "https://actorws.epa.gov/actorws/toxval/v01/toxval_source"
   actorws.dev <- "http://ag.epa.gov:8528/actorws/toxval/v01/toxval_source"
   non_hash_cols = c("chemical_id", "parent_chemical_id", "source_id","clowder_id","document_name","source_hash","qc_status",


### PR DESCRIPTION
changed long column name to critical_effect, split out toxval_numeric values that included units with them and toxval_type with them, got rid of rows with microorganisms and radionuclides as subsource_type, updated gsub, made sure total trihalomethanes value was not lost