### PR TITLE
TOXVAL-545

### DIFF
--- a/R/import_source_iris.R
+++ b/R/import_source_iris.R
@@ -437,10 +437,15 @@ import_source_iris <- function(db,chem.check.halt=FALSE, do.reset=FALSE, do.inse
         sex = sex_original,
         age = age_original
       )
+    # Set non-manually curated fields to blank
+    res1[, c(#"principal_study", "exposure_route", "critical_effect", "assessment_type",
+             "risk_assessment_duration", "endpoint")] <- "-"
     res = res0 %>%
-      dplyr::bind_rows(res1)
+      dplyr::bind_rows(res1) %>%
+      dplyr::distinct()
   } else {
-    res = res0
+    res = res0 %>%
+      dplyr::distinct()
   }
 
   # Fill blank hashing cols


### PR DESCRIPTION
Created parameter "do.summary_data" (default FALSE) that will process and insert IRIS summary data along with extraction data. Created key_finding and document_type field. Inserted logic for modifying and merging summary data inside if statement.
There are 6 columns from extraction that summary does not map to and 7 the other way around. I'm not sure how we want to handle these columns, whether dropping them or renaming (such as in the case of "sex" from extraction and "sex_original" in summary.