### PR TITLE
TOXVAL-463

### DIFF
--- a/R/import_hawc_source.R
+++ b/R/import_hawc_source.R
@@ -342,7 +342,7 @@ import_hawc_source <- function(db,
   # Dedup by collapsing non hashing columns
   res = res %>%
     dplyr::group_by(source_hash) %>%
-    dplyr::mutate(dplyr::across(tidyselect::all_of(c("experiment_id")),
+    dplyr::mutate(dplyr::across(-dplyr::any_of(c("source_hash", hashing_cols)),
                                 ~paste0(.[!is.na(.)], collapse=" |::| ") %>%
                                   dplyr::na_if("NA") %>%
                                   dplyr::na_if("")


### PR DESCRIPTION
Main changes were the removal of study_duration for "developmental" study_type records as it was determined to be misleading. These records were also primarily the issue with NA values but non NA units. I also did the same with one confusing reproductive study_type instance of "GD 0 to GD 0". There was also a request to have the link for hawc records point to the specific study url instead of the generic public/assessment url so I swapped study_url to source_url and what was source_url to assessment_url.