### PR TITLE
TOXVAL-550

### DIFF
--- a/R/import_source_epa_aegl.R
+++ b/R/import_source_epa_aegl.R
@@ -187,7 +187,8 @@ import_source_epa_aegl <- function(db,chem.check.halt=FALSE, do.reset=FALSE, do.
 
       # Set toxval_numeric to numeric type
       toxval_numeric = as.numeric(toxval_numeric)
-    )
+    ) %>%
+    tidyr::drop_na(toxval_numeric)
 
   # Fill blank hashing cols
   res[, toxval.config()$hashing_cols[!toxval.config()$hashing_cols %in% names(res)]] <- "-"


### PR DESCRIPTION
For cases where tables in the source data provide values for both ppm and mg/m3, the previous import script was only recording values for the second unit listed. I updated the import script to record separate entries for both units.