### PR TITLE
TOXVAL-604

### DIFF
--- a/R/import_niosh_source.R
+++ b/R/import_niosh_source.R
@@ -111,7 +111,9 @@ import_niosh_source <- function(db, chem.check.halt=FALSE, do.reset=FALSE, do.in
     ) %>%
 
     # Remove entries without necessary toxval columns
-    tidyr::drop_na(toxval_numeric, toxval_units)
+    tidyr::drop_na(toxval_numeric, toxval_units) %>%
+    # Remove "version" column from pivot
+    dplyr::select(-version)
 
   # Standardize the names
   names(res) <- names(res) %>%


### PR DESCRIPTION
Updated import script to use new web scrape data

Changes are relatively standard. I added new logic to use updated toxval_numeric values when available and to extract the year for each entry. Otherwise, I maintained old logic where possible and added some extra cleaning steps to account for the new data formatting.