### PR TITLE
TOXVAL-702

### DIFF
--- a/R/import_source_atsdr_mrls.R
+++ b/R/import_source_atsdr_mrls.R
@@ -128,11 +128,7 @@ import_source_atsdr_mrls <- function(db, chem.check.halt=FALSE, do.reset=FALSE, 
     summary_file = paste0(dir,"source_atsdr_mrls_manual_pod_awebb01_20240307.xlsx")
     res1 <- readxl::read_xlsx(summary_file) %>%
       dplyr::filter(toxval_type != "MRL") %>%
-      dplyr::mutate(document_type = "ATSDR MRLs Toxicological Profile",
-                    toxval_subtype = stringr::str_extract(toxval_type, "\\((.+)\\)", group=1),
-                    toxval_type = toxval_type %>%
-                      gsub("\\(.+\\)", "", .) %>%
-                      stringr::str_squish()) %>%
+      dplyr::mutate(document_type = "ATSDR MRLs Toxicological Profile") %>%
       dplyr::rename(long_ref = full_study_reference,
                     source_url = document_url,
                     species = species_original) %>%
@@ -150,6 +146,10 @@ import_source_atsdr_mrls <- function(db, chem.check.halt=FALSE, do.reset=FALSE, 
   # Combine with manual or provisional
   res = res %>%
     dplyr::bind_rows(res1) %>%
+    dplyr::mutate(toxval_subtype = stringr::str_extract(toxval_type, "\\((.+)\\)", group=1),
+                  toxval_type = toxval_type %>%
+                    gsub("\\(.+\\)", "", .) %>%
+                    stringr::str_squish()) %>%
     dplyr::distinct()
 
   # Fill blank hashing cols

--- a/R/import_source_iris.R
+++ b/R/import_source_iris.R
@@ -443,11 +443,8 @@ import_source_iris <- function(db,chem.check.halt=FALSE, do.reset=FALSE, do.inse
         iris_chemical_id = url %>%
           sub('.*=', '', .) %>%
           as.numeric(),
-        route = tolower(route),
-        toxval_subtype = stringr::str_extract(toxval_type, "\\((.+)\\)", group=1),
-        toxval_type = toxval_type %>%
-          gsub("\\(.+\\)", "", .) %>%
-          stringr::str_squish()) %>%
+        route = tolower(route)) %>%
+
       # Remove IRIS Export fields
       # dplyr::select(-principal_study, -document_type, -endpoint) %>%
       dplyr::rename(
@@ -478,7 +475,12 @@ import_source_iris <- function(db,chem.check.halt=FALSE, do.reset=FALSE, do.inse
       TRUE ~ NA_character_
     )) %>%
     # Remove qualifier symbols
-    dplyr::mutate(toxval_numeric = gsub("[<>=~]", "", toxval_numeric))
+    dplyr::mutate(toxval_numeric = gsub("[<>=~]", "", toxval_numeric),
+                  # Put parenthetic toxval_type values into toxval_subtype
+                  toxval_subtype = stringr::str_extract(toxval_type, "\\((.+)\\)", group=1),
+                  toxval_type = toxval_type %>%
+                    gsub("\\(.+\\)", "", .) %>%
+                    stringr::str_squish())
 
   # Handle ranged toxval_numeric values
   ranged_res = res %>% dplyr::filter(grepl("[0-9]+-[0-9]+", toxval_numeric))


### PR DESCRIPTION
Update the ATSDR MRLs and IRIS import scripts to split the toxval_type to put the parenthetical value into the toxval_subtype